### PR TITLE
fix: `gibberish_detector/config.py` to use `yaml.safe_load()`

### DIFF
--- a/gibberish_detector/config.py
+++ b/gibberish_detector/config.py
@@ -9,6 +9,6 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 CONFIG_PATH = "config.yml"
 
 with open(os.path.join(__location__, CONFIG_PATH), 'r') as ymlfile:
-    cfg = yaml.load(ymlfile)
+    cfg = yaml.safe_load(ymlfile)
     # Load the yaml content into this module global variables
     globals().update(cfg)


### PR DESCRIPTION
@alessandrodd 

A quick fix here to get the Dockerfile in [alessandrodd/api_key_extractor](https://github.com/alessandrodd/api_key_extractor) working again...

/bug